### PR TITLE
Rename tanix dtb

### DIFF
--- a/gxl_p281_1g_tanixtx3.dts
+++ b/gxl_p281_1g_tanixtx3.dts
@@ -1,7 +1,7 @@
 #include "gxl_p281_1g.dts"
 
 / {
-	le-dt-id = "gxl_p281_1g_tx3mini";
+	le-dt-id = "gxl_p281_1g_tanixtx3";
 
 	fd628_dev {
 		compatible = "amlogic,fd628_dev";

--- a/gxl_p281_2g_tanixtx3.dts
+++ b/gxl_p281_2g_tanixtx3.dts
@@ -1,7 +1,7 @@
 #include "gxl_p281_2g.dts"
 
 / {
-	le-dt-id = "gxl_p281_2g_tx3mini";
+	le-dt-id = "gxl_p281_2g_tanixtx3";
 
 	fd628_dev {
 		compatible = "amlogic,fd628_dev";


### PR DESCRIPTION
The following dtb has been reported to work on not just the tx3 mini but also the tx3 max, so renamed for less confusion for users.