### PR TITLE
Update X92 DTS to make the device tree work with the new driver.

### DIFF
--- a/gxm_q200_2g_x92.dts
+++ b/gxm_q200_2g_x92.dts
@@ -1,7 +1,7 @@
-#include "gxm_q200_3g.dts"
+#include "gxm_q200_2g.dts"
 
 / {
-	le-dt-id = "gxm_q200_3g_x92";
+	le-dt-id = "gxm_q200_2g_x92";
 
 	fd628_dev {
 		compatible = "amlogic,fd628_dev";


### PR DESCRIPTION
Edit: This PR is no longer required due to fd628 driver changes.

This change is required by the driver changes made in PR LibreELEC/LibreELEC.tv#2481, and should be merged after the LE PR is merged.