### PR TITLE
Fix T95Z display and Ethernet

### DIFF
--- a/gxm_q201_2g_t95z.dts
+++ b/gxm_q201_2g_t95z.dts
@@ -1,14 +1,14 @@
-#include "gxm_q200_3g.dts"
+#include "gxm_q201_2g.dts"
 
 / {
-	le-dt-id = "gxm_q200_3g_t95z";
+	le-dt-id = "gxm_q201_2g_t95z";
 
 	fd628_dev {
 		compatible = "amlogic,fd628_dev";
 		status = "okay";
-		fd628_gpio_clk = <&gpio GPIODV_26 GPIO_ACTIVE_HIGH>;
-		fd628_gpio_dat = <&gpio GPIODV_27 GPIO_ACTIVE_HIGH>;
-		fd628_gpio_stb = <&gpio GPIODV_25 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_clk = <&gpio GPIODV_22 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_dat = <&gpio GPIODV_23 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_stb = <&gpio GPIODV_21 GPIO_ACTIVE_HIGH>;
 		/* < DHHMM > Order of display chars (D=dots, represented by a single char) */
 		fd628_chars = /bits/ 8 <0 1 2 3 4>;
 		/* Dot enumeration */

--- a/gxm_q201_3g_t95z.dts
+++ b/gxm_q201_3g_t95z.dts
@@ -1,14 +1,14 @@
-#include "gxm_q200_2g.dts"
+#include "gxm_q201_3g.dts"
 
 / {
-	le-dt-id = "gxm_q200_2g_t95z";
+	le-dt-id = "gxm_q201_3g_t95z";
 
 	fd628_dev {
 		compatible = "amlogic,fd628_dev";
 		status = "okay";
-		fd628_gpio_clk = <&gpio GPIODV_26 GPIO_ACTIVE_HIGH>;
-		fd628_gpio_dat = <&gpio GPIODV_27 GPIO_ACTIVE_HIGH>;
-		fd628_gpio_stb = <&gpio GPIODV_25 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_clk = <&gpio GPIODV_22 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_dat = <&gpio GPIODV_23 GPIO_ACTIVE_HIGH>;
+		fd628_gpio_stb = <&gpio GPIODV_21 GPIO_ACTIVE_HIGH>;
 		/* < DHHMM > Order of display chars (D=dots, represented by a single char) */
 		fd628_chars = /bits/ 8 <0 1 2 3 4>;
 		/* Dot enumeration */


### PR DESCRIPTION
The pin mapping was wrong for the T95Z display. 
It also seems that 1Gbit isn't working under LibreELEC, so switching this DTB to Q201 with 100mbit ethernet.