### PR TITLE
Add A95X R2 (Abox A1 Max) specific DTBs.

### DIFF
--- a/gxl_p281_1g_a95xr2.dts
+++ b/gxl_p281_1g_a95xr2.dts
@@ -1,0 +1,9 @@
+#include "gxl_p281_1g.dts"
+
+/ {
+	le-dt-id = "gxl_p281_1g_a95xr2";
+
+	pinmux {
+		/delete-node/ internal_eth_pins;
+	};
+};

--- a/gxl_p281_2g_a95xr2.dts
+++ b/gxl_p281_2g_a95xr2.dts
@@ -1,0 +1,9 @@
+#include "gxl_p281_2g.dts"
+
+/ {
+	le-dt-id = "gxl_p281_2g_a95xr2";
+
+	pinmux {
+		/delete-node/ internal_eth_pins;
+	};
+};


### PR DESCRIPTION
As mentioned in #12, some devices still require DTBs.
In this case, the internal_eth_pins node in the master DTB conflicts with the pins used by the front led display.
Removing this node lets the display to work correctly, and doesn't break the built in ethernet either.